### PR TITLE
Add support for 2FA, fix minor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Oracle Patch Downloader
 
-The Oracle Patch Downloader can be used to download a list of patches from oracle.
+The Oracle Patch Downloader can be used to download a list of patches from Oracle.
 
 ## Precoditions
 
-- java >= 11
-- maven >= 3.9
+- java >= 1.8
+- maven >= 3.5.4
 - Oracle Support Account
 
 ## Installation
@@ -15,38 +15,45 @@ git clone git@github.com:ojehle/H35_OraclePatchDownloader.git
 cd H35_OraclePatchDownloader
 mvn install
 cd target
-## verfiy build, you can copy the file (its complete with all dependencies)
-java -jar OraclePatchDownloader-1.0.3.jar 
+# verify build, you can copy the file (it is complete with all dependencies)
+java -jar OraclePatchDownloader-1.0.3.jar
 ```
 
 ## Usage
 
-You can use the tool to download a list of patches, it accepts multiple -x or a list of patches delimited by comma.
-the regex can be used to filter out the files
+You can use the tool to download a list of patches, the regex can
+be used to filter out files.  You can specify patch lists and
+platform/language lists either as comma-separated lists
+(`-x p12345678,6880880`) or through multiple repeated options
+(`-x p12345678 -x 6880880`) or through a combination of these.
 
 ```sh
  -h : --help        help text
 
  -d : --directory   output folder, default user home
 
- -x : --patch       comma separated list of patches or multiple possible
+ -x : --patches     list of patches
+                    (e.g. "p12345678", "12345678")
 
- -f : --patchfile   patch list as file, one patch per line , line starting with # is ignored, format p12345678, 12345678
+ -f : --patchfile   file containing list of patches, one patch per line
+                    (e.g. "p12345678", "12345678", "# comment")
 
- -t : --plattform   Plattform Code 226P (Linux X86_64) or Langauge Code 4L, comma separated  
+ -t : --platforms   list of platforms or languages
+                    (e.g. "226P" for Linux x86-64 or "4L" for German (D))
 
  -r : --regex       regex for file filter, multiple possible
+                    (e.g. ".*1900.*")
 
  -u : --user        email/userid
 
  -p : --password    password
 
- -c : --check       check downloaded files against patchlist (-x: --patch) 
-                    assumes that the downloaded patch files contain the patch number for example: p333333.zip 
+ -2 : --2fatype     second factor type (one of "None", "TOTP", "SMS")
 
- -T : --temp        Temporary directory for HtmlUnit to use while downloading
-
+ -T : --temp        temporary directory
 ```
+
+For example:
 
 ```sh
 java -jar OraclePatchDownloader-1.0.3.jar -u user@h35.li -p password -x 200000 -t 226P,4L -r  ".*1900.*" -r  ".*19190.*" -d $HOME/Downloads
@@ -56,7 +63,7 @@ java -jar OraclePatchDownloader-1.0.3.jar -u user@h35.li -p password -x 200000 -
 
 | Code  | Plattform |
 | ----- | -------------------------------------|
-| 537P| Acme Packet 1100|  
+| 537P| Acme Packet 1100|
 | 529P| Acme Packet 3820|
 | 540P| Acme Packet 3900|
 | 561P| Acme Packet 3950|
@@ -156,47 +163,46 @@ java -jar OraclePatchDownloader-1.0.3.jar -u user@h35.li -p password -x 200000 -
 | 282P| x86 64 bit|
 | 67L| Albanian (SQ)|
 | 8L| Arabic (AR)|
-| 26L| Brazilian Portuguese (PTB)| 
+| 26L| Brazilian Portuguese (PTB)|
 | 101L| Bulgarian (BG)|
 | 3L| Canadian French (FRC)|
 | 102L| Catalan (CA)|
-| 103L| Croatian (HR)| 
-| 66L| Cyrillic Kazakh (CKK)| 
-| 62L| Cyrillic Serbian (CSR)| 
-| 30L| Czech (CS)| 
-| 5L| Danish (DK)| 
-| 6L| Dutch (NL)| 
-| 118L| ESTONIAN (ET)| 
-| 7L| Finnish (SF)| 
-| 2L| French (F)| 
-| 4L| German (D)| 
-| 104L| Greek (EL)| 
-| 107L| Hebrew (IW)| 
-| 28L| Hungarian (HU)| 
-| 106L| Icelandic (IS)| 
-| 46L| Indonesian (IN)| 
-| 108L| Italian (I)| 
-| 15L| Japanese (JA)| 
-| 16L| Korean (KO)| 
-| 29L| Latin American Spanish (ESA)| 
-| 63L| Latin Serbian (LSR)| 
-| 119L| LATVIAN (LV)| 
-| 109L| Lithuanian (LT)| 
-| 10L| Norwegian (N)| 
-| 110L| Polish (PL)| 
-| 18L| Portuguese (PT)| 
-| 111L| Romanian (RO)| 
-| 112L| Russian (RU)| 
-| 14L| Simplified Chinese (ZHS)| 
-| 113L| Slovak (SK)| 
-| 114L| Slovenian (SL)| 
-| 11L| Spanish (E)| 
-| 13L| Swedish (S)| 
-| 115L| Thai (TH)| 
-| 117L| Traditional Chinese (ZHT)| 
-| 116L| Turkish (TR)| 
-| 37L| UK English (GB)| 
-| 39L| Ukrainian (UK)| 
-| 43L| Vietnamese (VN)| 
-| 999L| Worldwide Spanish (ESW)| 
-
+| 103L| Croatian (HR)|
+| 66L| Cyrillic Kazakh (CKK)|
+| 62L| Cyrillic Serbian (CSR)|
+| 30L| Czech (CS)|
+| 5L| Danish (DK)|
+| 6L| Dutch (NL)|
+| 118L| ESTONIAN (ET)|
+| 7L| Finnish (SF)|
+| 2L| French (F)|
+| 4L| German (D)|
+| 104L| Greek (EL)|
+| 107L| Hebrew (IW)|
+| 28L| Hungarian (HU)|
+| 106L| Icelandic (IS)|
+| 46L| Indonesian (IN)|
+| 108L| Italian (I)|
+| 15L| Japanese (JA)|
+| 16L| Korean (KO)|
+| 29L| Latin American Spanish (ESA)|
+| 63L| Latin Serbian (LSR)|
+| 119L| LATVIAN (LV)|
+| 109L| Lithuanian (LT)|
+| 10L| Norwegian (N)|
+| 110L| Polish (PL)|
+| 18L| Portuguese (PT)|
+| 111L| Romanian (RO)|
+| 112L| Russian (RU)|
+| 14L| Simplified Chinese (ZHS)|
+| 113L| Slovak (SK)|
+| 114L| Slovenian (SL)|
+| 11L| Spanish (E)|
+| 13L| Swedish (S)|
+| 115L| Thai (TH)|
+| 117L| Traditional Chinese (ZHT)|
+| 116L| Turkish (TR)|
+| 37L| UK English (GB)|
+| 39L| Ukrainian (UK)|
+| 43L| Vietnamese (VN)|
+| 999L| Worldwide Spanish (ESW)|

--- a/src/main/java/li/h35/OraclePatchDownloader/OraclePatchDownloader.java
+++ b/src/main/java/li/h35/OraclePatchDownloader/OraclePatchDownloader.java
@@ -32,6 +32,7 @@ import org.htmlunit.Page;
 import org.htmlunit.UnexpectedPage;
 import org.htmlunit.WebClient;
 import org.htmlunit.html.DomElement;
+import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlInput;
 import org.htmlunit.html.HtmlPage;
@@ -43,6 +44,8 @@ import gnu.getopt.Getopt;
 import gnu.getopt.LongOpt;
 
 public class OraclePatchDownloader {
+	private static enum SecondFAType { None, TOTP, SMS }
+
 	private static String patchRegex = "^([p]{0,1})([0-9]{8}).*$";
 	private static Pattern patchPattern = Pattern.compile(patchRegex);
 	private static String regex = "(?:^|\\?|&)patch_file=(.*?)(?:&|$)";
@@ -52,7 +55,8 @@ public class OraclePatchDownloader {
 	private static boolean tempdirDelete = false;
 	private static String user = null;
 	private static String password = null;
-	private static ArrayList<String> plattform = new ArrayList<String>();
+	private static SecondFAType secondFAType = SecondFAType.None;
+	private static ArrayList<String> platformList = new ArrayList<String>();
 	private static boolean checkPatchList = false;
 	private static ArrayList<Pattern> patchRegexp = new ArrayList<Pattern>();
 	private static ArrayList<String> patchList = new ArrayList<String>();
@@ -65,9 +69,9 @@ public class OraclePatchDownloader {
 		return "";
 	}
 
-	public String getDownloadUrl(String patch, String plattform) {
+	public String getDownloadUrl(String patch, String platform) {
 		return "https://updates.oracle.com/Orion/SimpleSearch/process_form?search_type=patch&patch_number=" + patch
-				+ "&plat_lang=" + plattform;
+				+ "&plat_lang=" + platform;
 	}
 
 	public boolean isPatchDownloaded(String patch) {
@@ -81,11 +85,21 @@ public class OraclePatchDownloader {
 
 	public OraclePatchDownloader() {
 		ArrayList<String> downloads = new ArrayList<String>();
-		boolean loggedIn = false;
 
-		WebClient webClient = new WebClient(BrowserVersion.FIREFOX);
+		// force english content since we identify login progress by
+		// (localized) content
+		BrowserVersion.BrowserVersionBuilder browserVersionBuilder =
+			new BrowserVersion.BrowserVersionBuilder(BrowserVersion.FIREFOX);
+		browserVersionBuilder.setBrowserLanguage("en-US");
+		browserVersionBuilder.setAcceptLanguageHeader("en-US");
+		WebClient webClient = new WebClient(browserVersionBuilder.build());
+
 		webClient.getOptions().setJavaScriptEnabled(true);
 		Logger.getLogger("org.htmlunit").setLevel(Level.SEVERE);
+		// some OAM villains try to set invalid cookies - silence the
+		// corresponding org.apache.http.client warnings
+		Logger.getLogger("org.apache.http.client.protocol.ResponseProcessCookies")
+			.setLevel(Level.SEVERE);
 		HtmlPage page = null;
 		try {
 			webClient.getOptions().setTempFileDirectory(tempdir);
@@ -93,9 +107,11 @@ public class OraclePatchDownloader {
 			for (String patch : patchList) {
 				if (isPatchDownloaded(patch))
 					continue;
-				for (String p : plattform) {
-					page = webClient.getPage(getDownloadUrl(patch, p));
-					if (!loggedIn) {
+				for (String platform : platformList) {
+					page = webClient.getPage(getDownloadUrl(patch, platform));
+
+					if (page.getTitleText().equals("Oracle Login - Single Sign On")) {
+						System.out.println("Processing login page...");
 						for (HtmlForm f : page.getForms()) {
 							if (f.getNameAttribute().equalsIgnoreCase("LoginForm")) {
 								HtmlForm form = page.getFormByName("LoginForm");
@@ -103,11 +119,60 @@ public class OraclePatchDownloader {
 								form.getInputByName("password").type(password);
 								HtmlInput in = page.getHtmlElementById("signin_button");
 								page = in.click(); // works fine
-								page = webClient.getPage(getDownloadUrl(patch, p));
 							}
 						}
 					}
 
+					if (page.getTitleText().equals("Login - Oracle Access Management 11g") &&
+							page.getElementById("loginForm") != null &&
+							page.getElementById("loginForm").asNormalizedText()
+									.indexOf("Please choose your preferred method") >= 0) {
+						System.out.println("Processing 2FA selection page...");
+						if (secondFAType.equals(SecondFAType.TOTP) &&
+								page.getHtmlElementById("Totp") != null) {
+							page.getHtmlElementById("Totp").click();
+						}
+						else if (secondFAType.equals(SecondFAType.SMS) &&
+										 page.getHtmlElementById("Sms") != null) {
+							page.getHtmlElementById("Sms").click();
+						}
+						else {
+							System.err.println("Cannot process 2FA selection page");
+							System.exit(1);
+						}
+						page = ((HtmlElement)page.querySelector("input.formButton")).click();
+					}
+
+					if (page.getTitleText().equals("Login - Oracle Access Management 11g") &&
+							page.querySelector("label[for='username']") != null &&
+							page.querySelector("label[for='username']").asNormalizedText()
+									.equals("Enter One Time Pin:")) {
+						System.out.println("Processing 2FA entry page...");
+						String prompt;
+						if (secondFAType.equals(SecondFAType.TOTP)) {
+							prompt = "TOTP: ";
+						}
+						else if (secondFAType.equals(SecondFAType.SMS)) {
+							prompt = "SMS PIN: ";
+						}
+						else {
+							prompt = null;
+							System.err.println("Cannot process 2FA entry page");
+							System.exit(1);
+						}
+						String otp = System.console().readLine(prompt);
+						page.getHtmlElementById("passcode").type(otp);
+						page = ((HtmlElement)page.querySelector("input[type='submit']")).click();
+					}
+
+					// ensure we ended up on the patch search results,
+					// otherwise bail out
+					if (! page.getTitleText().equals("Search Results")) {
+						System.err.println("Cannot process page \"" + page.getTitleText() + "\" - login failed?");
+						System.exit(1);
+					}
+
+					System.out.println("Processing search results...");
 					for (DomElement e : page.getElementsByTagName("table")) {
 						if (e instanceof HtmlTable) {
 							for (HtmlTableRow r : ((HtmlTable) e).getRows()) {
@@ -131,6 +196,12 @@ public class OraclePatchDownloader {
 								}
 							}
 						}
+					}
+
+					// bail out if no downloads have been selected
+					if (downloads.size() == 0) {
+						System.err.println("Cannot process empty download list");
+						System.exit(1);
 					}
 				}
 			}
@@ -175,43 +246,47 @@ public class OraclePatchDownloader {
 	}
 
 	private static void help() {
-		System.out.println("usage:");
+		System.out.println("Usage:");
 		System.out.println(" -h : --help        help text");
 		System.out.println(" -d : --directory   output folder, default user home");
-		System.out.println(" -x : --patch       comma separated list of patches or multiple possible");
-		System.out.println(" -f : --patchfile   patch list as file, one patch per line , # is ignored");
-		System.out.println(
-				" -t : --plattform   Plattform Code 226P (Linux X86_64) or Langauge Code 4L, comma separated  ");
+		System.out.println(" -x : --patches     list of patches");
+		System.out.println("                    (e.g. \"p12345678\", \"12345678\")");
+		System.out.println(" -f : --patchfile   file containing list of patches, one patch per line");
+		System.out.println("                    (e.g. \"p12345678\", \"12345678\", \"# comment\")");
+		System.out.println(" -t : --platforms   list of platforms or languages");
+		System.out.println("                    (e.g. \"226P\" for Linux x86-64 or \"4L\" for German (D))");
 		System.out.println(" -r : --regex       regex for file filter, multiple possible");
+		System.out.println("                    (e.g. \".*1900.*\")");
 		System.out.println(" -u : --user        email/userid");
 		System.out.println(" -p : --password    password");
-		System.out.println(" -c : --check       check patchlist after download");
-		System.out.println(" -T : --temp        Temporary Directory");
+		System.out.println(" -2 : --2fatype     second factor type (one of \"None\", \"TOTP\", \"SMS\")");
+		System.out.println(" -T : --temp        temporary directory");
 	}
 
 	public static void main(String[] args) {
 
 		int c;
-		LongOpt[] longopts = new LongOpt[10];
-		longopts[0] = new LongOpt("help", LongOpt.NO_ARGUMENT, null, 'h');
-		longopts[1] = new LongOpt("check", LongOpt.NO_ARGUMENT, null, 'c');
-		longopts[2] = new LongOpt("directory", LongOpt.REQUIRED_ARGUMENT, null, 'd');
-		longopts[3] = new LongOpt("patches", LongOpt.REQUIRED_ARGUMENT, null, 'x');
-		longopts[4] = new LongOpt("plattform", LongOpt.REQUIRED_ARGUMENT, null, 't');
-		longopts[5] = new LongOpt("regex", LongOpt.REQUIRED_ARGUMENT, null, 'r');
-		longopts[6] = new LongOpt("user", LongOpt.REQUIRED_ARGUMENT, null, 'u');
-		longopts[7] = new LongOpt("password", LongOpt.REQUIRED_ARGUMENT, null, 'p');
-		longopts[8] = new LongOpt("patchfile", LongOpt.REQUIRED_ARGUMENT, null, 'f');
-		longopts[9] = new LongOpt("temp", LongOpt.REQUIRED_ARGUMENT, null, 'T');
+		ArrayList<LongOpt> longopts = new ArrayList<>();
+		longopts.add( new LongOpt("help",      LongOpt.NO_ARGUMENT,       null, 'h') );
+		longopts.add( new LongOpt("directory", LongOpt.REQUIRED_ARGUMENT, null, 'd') );
+		longopts.add( new LongOpt("patches",   LongOpt.REQUIRED_ARGUMENT, null, 'x') );
+		longopts.add( new LongOpt("patchfile", LongOpt.REQUIRED_ARGUMENT, null, 'f') );
+		longopts.add( new LongOpt("platforms", LongOpt.REQUIRED_ARGUMENT, null, 't') );
+		longopts.add( new LongOpt("regex",     LongOpt.REQUIRED_ARGUMENT, null, 'r') );
+		longopts.add( new LongOpt("user",      LongOpt.REQUIRED_ARGUMENT, null, 'u') );
+		longopts.add( new LongOpt("password",  LongOpt.REQUIRED_ARGUMENT, null, 'p') );
+		longopts.add( new LongOpt("2fatype",   LongOpt.REQUIRED_ARGUMENT, null, '2') );
+		longopts.add( new LongOpt("temp",      LongOpt.REQUIRED_ARGUMENT, null, 'T') );
 
-		Getopt g = new Getopt("OraclePatchDownoader", args, "hcd:t:x:r:u:p:f:T:", longopts);
+		Getopt g = new Getopt("OraclePatchDownoader", args, "hd:x:f:t:r:u:p:2:T:",
+													longopts.toArray(new LongOpt[0]));
 		directory = new File(System.getProperty("user.home"));
 		tempdir = new File(System.getProperty("java.io.tmpdir"));
 
 		while ((c = g.getopt()) != -1)
 			switch (c) {
 			case 'h':
-				System.out.println("usage:");
+				help();
 				System.exit(0);
 				break;
 
@@ -223,25 +298,11 @@ public class OraclePatchDownloader {
 				}
 				break;
 
-			//
-			case 'r':
-				Pattern p = null;
-				String s = g.getOptarg();
-				try {
-					p = Pattern.compile(s);
-				} catch (Exception e) {
-					System.err.println("cannot parse regexp : " + s);
-					e.printStackTrace();
-					System.exit(1);
-				}
-				if (p != null)
-					patchRegexp.add(p);
-				break;
-
 			case 'x':
-				String[] pl = g.getOptarg().split(",");
-				for (String patch : pl) {
-					patchList.add(patch);
+				for (String patch : g.getOptarg().split("[,;]+")) {
+					if (patch.length() > 0) {
+						patchList.add(patch);
+					}
 				}
 				break;
 
@@ -264,23 +325,53 @@ public class OraclePatchDownloader {
 						System.exit(1);
 					}
 				}
+        else {
+					System.err.println("Cannot find file \"" + fp + "\"");
+					System.exit(1);
+        }
 				break;
 
 			case 't':
-				String pa = g.getOptarg();
-				pa = pa.replace(";", ",");
-				String[] pal = pa.split(",");
-				for (String px : pal) {
-					plattform.add(px);
+				for (String platform : g.getOptarg().split("[,;]+")) {
+					if (platform.length() > 0) {
+						platformList.add(platform);
+					}
 				}
+				break;
 
+			case 'r':
+				Pattern p = null;
+				String s = g.getOptarg();
+				try {
+					p = Pattern.compile(s);
+				} catch (Exception e) {
+					System.err.println("cannot parse regexp : " + s);
+					e.printStackTrace();
+					System.exit(1);
+				}
+				if (p != null)
+					patchRegexp.add(p);
 				break;
-			case 'p':
-				password = g.getOptarg();
-				break;
+
 			case 'u':
 				user = g.getOptarg();
 				break;
+
+			case 'p':
+				password = g.getOptarg();
+				break;
+
+			case '2':
+				try {
+					secondFAType = SecondFAType.valueOf(g.getOptarg());
+				}
+				catch (IllegalArgumentException e) {
+					System.err.println("Invalid 2FA type \"" + g.getOptarg() + "\"");
+					help();
+					System.exit(1);
+				}
+				break;
+
 			case 'T':
 				tempdir = new File(g.getOptarg());
 				if (!tempdir.exists()) {
@@ -295,30 +386,32 @@ public class OraclePatchDownloader {
 				break;
 			}
 
+		if (patchList.size() == 0) {
+			System.err.println("No patches specified");
+			help();
+			System.exit(1);
+		}
+		if (platformList.size() == 0) {
+			System.err.println("No platforms specified");
+			help();
+			System.exit(1);
+		}
 		if (user == null || password == null) {
 			System.err.println("User or Password missing");
 			help();
 			System.exit(1);
 		}
-		if (plattform == null) {
-			System.err.println("Plattform missing");
-			help();
-			System.exit(1);
-		}
-		if (patchList.size() == 0) {
-			System.err.println("no patches specified");
-			help();
-			System.exit(1);
-		}
 
-		new OraclePatchDownloader();
-		
-		if (tempdirDelete) {
-			for (File f : tempdir.listFiles())
-			{
-				f.delete();
+		try {
+			new OraclePatchDownloader();
+		}
+		finally {
+			if (tempdirDelete) {
+				for (File f : tempdir.listFiles()) {
+					f.delete();
+				}
+				tempdir.delete();
 			}
-			tempdir.delete();
 		}
 
 	}


### PR DESCRIPTION
OraclePatchDownloader.java:

- Add support for 2FA.

- Fix typos and terminology.

- Make recognition of login page more robust.

- Suppress annoying cookie warnings.

- Add more process reporting.

- Report an error when no downloads were selected.

- Make online help and order of command line processing more consistent.  Brush up online help in general.

- Remove documentation on option "--check", which is currently a no-op, anyway.

- Fix option "--help" not printing online help.

- Make handling of lists more robust and consistent.

- Report an error if file with list of patches is missing.

- Fix check on missing "--platforms" option.

- Clean up temporary directory also in case of errors.

README.md:

- Fix typos and terminology.

- Lower minimum required versions.

- Explain list handling in a more general fashion.

- Synch option description from online help.

- Fix superfluous trailing whitespace.