### PR TITLE
Improve error handling and debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ platform/language lists either as comma-separated lists
 
  -u : --user        email/userid
 
- -p : --password    password ("ENV_VAR" to use password from env)
+ -p : --password    password ("env:ENV_VAR" to use password from env)
 
  -2 : --2fatype     second factor type (one of "None", "TOTP", "SMS")
 
@@ -70,7 +70,7 @@ For example:
 
 ```sh
 export MOS_PASSWORD="my secret MOS password"
-java -jar OraclePatchDownloader-1.0.4.jar -u user@h35.li -p MOS_PASSWORD \
+java -jar OraclePatchDownloader-1.0.4.jar -u user@h35.li -p env:MOS_PASSWORD \
      -x 200000 -t 226P,4L -r ".*1900.*" -r ".*19190.*" -d $HOME/Downloads
 ```
 


### PR DESCRIPTION
### Improve previous password entry changes

OraclePatchDownloader.java:

- Factor out common code from methods readLine and readPassword
  to a new method readThing.  Protect from reading EOF in that
  method.

- Change syntax for reading passwords from environment to a more
  explicit env:ENV_VAR.

- Simplify calls to readLine, readPrompt.

README.md:

- Sync online help.

- Change example to the env:ENV_VAR syntax.

### Clean up code

OraclePatchDownloader.java:

- Reorder definitions of global variables to be more consistent
  with rest of code.

- Make variable tempdirDelete local to main method, renamed
  patchRegexp to patternList.

- Completely remove unused code referring to checkPatchList.
  (That variable never gets set to true as of commit 7aaba1e.)

- Consistently use "private static" methods, make the constructor
  a "public static" method.

- Check for empty download list after processing all search
  results.

- Move exception handling from method download to main to avoid
  exiting prematurely (thus circumventing clean-up code in main).

- Simplify handling of patterns in command line processing.

### Streamline error handling

OraclePatchDownloader.java:

- Add methods format(), error(), warn(), usage() as main APIs to
  handle errors and use them as appropriate.  When none of these
  is appropriate, throw a RuntimeExcpetion.  Extend main method
  to handle any ExitExceptions thrown by the new methods.

- Redo web scraping to use methods that throw
  ElementNotFoundExceptions when a page does not look as
  expected.  Handle these exceptions.

- Simplify download link loop by using an XPath query.

- Turn "no dowmloads error" into a warning (since this is a
  legitimate use case, not an error).

- Use try-with-resource where appropriate.
