### PR TITLE
Add page dumps and request log, upload temporary artifacts

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -39,7 +39,7 @@ jobs:
       # https://github.com/actions/checkout/issues/701,
       # https://github.com/actions/checkout/issues/1467.
       - name: Fetch Release Tag
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: git fetch --force --tags origin "${{ github.ref }}"
 
       - name: Set up JDK 8
@@ -52,8 +52,16 @@ jobs:
       - name: Build with Maven
         run: mvn --batch-mode package
 
+      - name: Upload Temporary Artifact
+        if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: target/oraclePatchDownloader-*.*.*.jar
+          compression-level: 0
+          overwrite: true
+
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash -e -o pipefail {0}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ and the platform/language list either as comma-separated lists
 ```
  -h : --help        help text
 
+ -D : --debug       debug mode
+
+ -q : --quiet       quiet mode
+
  -d : --directory   output folder, default user home
 
  -x : --patches     list of patches
@@ -74,7 +78,7 @@ and the platform/language list either as comma-separated lists
  -T : --temp        temporary directory
 ```
 
-### Specifying the Password
+### Specifying Passwords
 
 Specifying passwords on the command line is inherently unsafe, in
 particular on multi-user systems.  You should better enter the
@@ -84,6 +88,24 @@ you do not specify option `--password`.
 Or you can store the password in an environment variable and pass
 a reference to that variable in the argument to option
 `--password`, as shown in the example below.
+
+### Debug Mode
+
+In debug mode the Oracle Patch Downloader dumps all HTML pages
+that it processes to the output folder.  In addition, it logs
+HTTP requests and responses to a log file, also placed in the
+output folder.  The downloader uses file names
+`dump-<hex-timestamp>-<page-title>.xml` for dumps of regular
+pages and file names `error-<hex-timestamp>-<page-title>.xml` for
+dumps of pages it could not process.
+
+**Note that the log file most certainly contains sensitive data,
+likewise for the page dumps.**
+
+The Downloader uses the APIs provided by HtmlUnit to dump HTML
+pages and log HTTP requests and responses.  The information
+retrieved through these APIs differs from the actual data sent
+over the wire.
 
 ### Example
 

--- a/src/main/java/li/h35/OraclePatchDownloader/OraclePatchDownloader.java
+++ b/src/main/java/li/h35/OraclePatchDownloader/OraclePatchDownloader.java
@@ -20,12 +20,17 @@ import java.io.Console;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.IllegalFormatException;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -35,8 +40,11 @@ import java.util.regex.PatternSyntaxException;
 import org.htmlunit.BrowserVersion;
 import org.htmlunit.ElementNotFoundException;
 import org.htmlunit.Page;
+import org.htmlunit.SgmlPage;
 import org.htmlunit.UnexpectedPage;
 import org.htmlunit.WebClient;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
 import org.htmlunit.html.DomElement;
 import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlForm;
@@ -45,6 +53,8 @@ import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlTable;
 import org.htmlunit.html.HtmlTableCell;
 import org.htmlunit.html.HtmlTableRow;
+import org.htmlunit.util.NameValuePair;
+import org.htmlunit.util.WebConnectionWrapper;
 
 import gnu.getopt.Getopt;
 import gnu.getopt.LongOpt;
@@ -52,13 +62,26 @@ import gnu.getopt.LongOpt;
 public class OraclePatchDownloader {
 	private static enum SecondFAType { None, TOTP, SMS }
 
+	//-----------------------------------------------------------------
 	// constants
-	private static String patchRegex = "^([p]{0,1})([0-9]{8}).*$";
-	private static Pattern patchPattern = Pattern.compile(patchRegex);
-	private static String regex = "(?:^|\\?|&)patch_file=(.*?)(?:&|$)";
-	private static Pattern pattern = Pattern.compile(regex);
+	//-----------------------------------------------------------------
 
+	// regex that finds a patch file name in a patch download URL.
+	// The first subgroup provides the patch file name.
+	private final static String  PATCH_URL_FILE_REGEX   = "(?:^|\\?|&)patch_file=(.*?)(?:&|$)";
+	private final static Pattern PATCH_URL_FILE_PATTERN = Pattern.compile(PATCH_URL_FILE_REGEX);
+
+	// regex that matches a line in a patch file.  The first
+	// subgroup provides the patch number.
+	private final static String  PATCH_FILE_LINE_REGEX   = "^p?(\\d{8,10}).*$";
+	private final static Pattern PATCH_FILE_LINE_PATTERN = Pattern.compile(PATCH_FILE_LINE_REGEX);
+
+	//-----------------------------------------------------------------
 	// "global" variables
+	//-----------------------------------------------------------------
+
+	private static boolean debugMode = false;
+	private static boolean quietMode = false;
 	private static File directory = null;
 	private static ArrayList<String> patchList = new ArrayList<String>();
 	private static ArrayList<String> platformList = new ArrayList<String>();
@@ -66,11 +89,15 @@ public class OraclePatchDownloader {
 	private static String user = null;
 	// do not use a character array here plus some "burn after
 	// reading" processing, even if that is the general convention
-	// for handling passwords.  We need the password also to ensure
-	// its absence in page dumps, which seems to be more importamt.
+	// for handling passwords.  The security gain does not seem to
+	// justify the effort required to do so.
 	private static String password = null;
 	private static SecondFAType secondFAType = SecondFAType.None;
 	private static File tempdir = null;
+
+	//-----------------------------------------------------------------
+	// string formatting
+	//-----------------------------------------------------------------
 
 	// like String.format, but protects against format errors.
 	// This is to avoid exception handling resulting in exceptions,
@@ -94,6 +121,10 @@ public class OraclePatchDownloader {
 			return result.toString();
 		}
 	}
+
+	//-----------------------------------------------------------------
+	// errors, warnings, progress
+	//-----------------------------------------------------------------
 
 	// Try to handle errors in this tool as follows:
 	//
@@ -119,6 +150,8 @@ public class OraclePatchDownloader {
 		System.err.println(format(format, args));
 		if (e != null)
 			e.printStackTrace(System.err);
+		if (p != null && debugMode)
+			dumpInternal(p, true);
 		throw new ExitException(1);
 	}
 
@@ -137,13 +170,117 @@ public class OraclePatchDownloader {
 		error(format, (Exception)null, (Page)null, args);
 	}
 
-	private static void warn(String format, Object... args) {
+	private static void warn(String format, Exception e, Object... args) {
 		System.err.println(format(format, args));
+		if (e != null)
+			e.printStackTrace(System.err);
+	}
+
+	private static void warn(String format, Object... args) {
+		warn(format, (Exception)null, args);
 	}
 
 	private static void progress(String format, Object... args) {
-		System.err.println(format(format, args));
+		if (! quietMode)
+			System.err.println(format(format, args));
 	}
+
+	//-----------------------------------------------------------------
+	// logging and dumping
+	//-----------------------------------------------------------------
+
+	private static void rrlog(PrintWriter rrLogWriter, WebRequest request) {
+		try {
+			// dump request.  Use some dummy HTTP version, since the
+			// real one does not seem to be easily available.
+			long ctm = System.currentTimeMillis();
+			rrLogWriter.println(format("%s %s HTTP/0.0 (%tF %tT)",
+																 request.getHttpMethod(),
+																 request.getUrl(),
+																 ctm, ctm));
+			for (Map.Entry<String, String> header :
+						 new TreeMap<>(request.getAdditionalHeaders()).entrySet())
+				rrLogWriter.println(format("%s=%s", header.getKey(), header.getValue()));
+			List<NameValuePair> parameters = request.getRequestParameters();
+			if (parameters.size() > 0)
+				rrLogWriter.println();
+			for (NameValuePair parameter : parameters)
+				rrLogWriter.println(parameter);
+			rrLogWriter.println();
+			rrLogWriter.flush();
+		}
+		catch (Exception e) {
+			warn("Cannot write to request-response log file", e);
+		}
+	}
+
+	private static void rrlog(PrintWriter rrLogWriter, WebResponse response) {
+		try {
+			// dump response
+			long ctm = System.currentTimeMillis();
+			rrLogWriter.println(format("HTTP/0.0 %03d %s (%tF %tT)",
+																 response.getStatusCode(),
+																 response.getStatusMessage(),
+																 ctm, ctm));
+			for (NameValuePair header : response.getResponseHeaders())
+				rrLogWriter.println(header);
+			rrLogWriter.println();
+			rrLogWriter.println(format("<content of length %d>",
+																 response.getContentLength()));
+			rrLogWriter.println();
+			rrLogWriter.flush();
+		}
+		catch (Exception e) {
+			warn("Cannot write to request-response log file", e);
+		}
+	}
+
+	private static void dumpInternal(Page page, boolean onerror) {
+		try {
+			// determine some human-readable page Id
+			String pageId =
+				(page instanceof HtmlPage) ?
+				((HtmlPage)page).getTitleText() :
+				page.getUrl().toString();
+
+			// ensure page Id consists entirely of sane characters
+			pageId = pageId.toLowerCase()
+				.replaceFirst("\\A[^0-9a-z]+", "")
+				.replaceFirst("[^0-9a-z]+\\z", "")
+				.replaceAll("[^0-9a-z]+", "-");
+			if (pageId.length() == 0)
+				pageId = String.format("%08x", page.hashCode());
+
+			// determine dump file name
+			String dfn =
+				String.format("%s-%016x-%s.%s",
+											onerror ? "error" : "dump",
+											System.currentTimeMillis(), pageId,
+											(page instanceof SgmlPage) ? "xml" : "txt");
+
+			try (FileWriter dfw = new FileWriter(new File(directory, dfn))) {
+				if (page instanceof SgmlPage)
+					dfw.write(((SgmlPage)page).asXml());
+				else
+					dfw.write(page.toString());
+			}
+			catch (IOException e) {
+				warn("Cannot write dump file \"%s\"", e, dfn);
+			}
+		}
+		catch (Exception e) {
+			warn("Cannot write page dump file", e);
+		}
+	}
+
+	private static void dump(Page page) {
+		if (debugMode)
+			dumpInternal(page, false);
+	}
+
+	//-----------------------------------------------------------------
+	// user input
+	//-----------------------------------------------------------------
 
 	private static String readThing(boolean password, String prompt, Object... args) {
 		Console console = System.console();
@@ -183,8 +320,12 @@ public class OraclePatchDownloader {
 		return readThing(true, prompt, args);
 	}
 
+	//-----------------------------------------------------------------
+	// auxilliary methods
+	//-----------------------------------------------------------------
+
 	private static String getPatchFile(String url) {
-		Matcher matcher = pattern.matcher(url);
+		Matcher matcher = PATCH_URL_FILE_PATTERN.matcher(url);
 		if (matcher.find()) {
 			return matcher.group(1);
 		}
@@ -205,6 +346,10 @@ public class OraclePatchDownloader {
 		return list.length > 0;
 	}
 
+	//-----------------------------------------------------------------
+	// download
+	//-----------------------------------------------------------------
+
 	public static void download() throws Exception {
 		ArrayList<String> downloads = new ArrayList<String>();
 
@@ -215,9 +360,38 @@ public class OraclePatchDownloader {
 		browserVersionBuilder.setBrowserLanguage("en-US");
 		browserVersionBuilder.setAcceptLanguageHeader("en-US");
 
-		try (WebClient webClient = new WebClient(browserVersionBuilder.build())) {
+		// determine request-response log file
+		File rrLogFile;
+		if (debugMode)
+			rrLogFile = new File(directory,
+													 String.format("%s-%016x.%s",
+																				 "reqresp",
+																				 System.currentTimeMillis(),
+																				 "log"));
+		else
+			rrLogFile = null;
+
+		try (WebClient webClient = new WebClient(browserVersionBuilder.build());
+				 PrintWriter rrLogWriter =
+					 debugMode ?
+					 new PrintWriter(new FileWriter(rrLogFile)) :
+					 null) {
 			webClient.getOptions().setJavaScriptEnabled(true);
 			webClient.getOptions().setTempFileDirectory(tempdir);
+
+			// set a custom web connection wrapper to be able to log
+			// requests and their responses
+			webClient.setWebConnection(new WebConnectionWrapper(webClient) {
+				@Override
+				public WebResponse getResponse(WebRequest request) throws IOException {
+					if (debugMode)
+						rrlog(rrLogWriter, request);
+					WebResponse response = super.getResponse(request);
+					if (debugMode)
+						rrlog(rrLogWriter, response);
+					return response;
+				}
+			});
 
 			Logger.getLogger("org.htmlunit").setLevel(Level.SEVERE);
 			// some OAM villains try to set invalid cookies - silence
@@ -232,6 +406,7 @@ public class OraclePatchDownloader {
 					continue;
 				for (String platform : platformList) {
 					page = webClient.getPage(getDownloadUrl(patch, platform));
+					dump(page);
 
 					// A short overview on how HtmlUnit methods react when
 					// some element is absent:
@@ -253,6 +428,7 @@ public class OraclePatchDownloader {
 							form.getInputByName("ssousername").type(user);
 							form.getInputByName("password").type(password);
 							page = page.getHtmlElementById("signin_button").click();
+							dump(page);
 						}
 						catch (ElementNotFoundException e) {
 							error("Cannot process login page", e, page);
@@ -276,6 +452,7 @@ public class OraclePatchDownloader {
 								error("Cannot process 2FA selection page", page);
 							}
 							page = form.getInputByValue("OK").click();
+							dump(page);
 						}
 						catch (ElementNotFoundException e) {
 							error("Cannot process 2FA selection page", e, page);
@@ -303,6 +480,7 @@ public class OraclePatchDownloader {
 							HtmlForm form = page.getFormByName("loginForm");
 							form.getInputByName("passcode").type(otp);
 							page = form.getInputByValue("Login").click();
+							dump(page);
 						}
 						catch (ElementNotFoundException e) {
 							error("Cannot process 2FA entry page", e, page);
@@ -368,9 +546,15 @@ public class OraclePatchDownloader {
 		}
 	}
 
+	//-----------------------------------------------------------------
+	// main method and friends
+	//-----------------------------------------------------------------
+
 	private static void help() {
 		System.out.println("Usage:");
 		System.out.println(" -h : --help        help text");
+		System.out.println(" -D : --debug       debug mode");
+		System.out.println(" -q : --quiet       quiet mode");
 		System.out.println(" -d : --directory   output folder, default user home");
 		System.out.println(" -x : --patches     list of patches");
 		System.out.println("                    (e.g. \"p12345678\", \"12345678\")");
@@ -382,7 +566,6 @@ public class OraclePatchDownloader {
 		System.out.println("                    (e.g. \".*1900.*\")");
 		System.out.println(" -u : --user        email/userid");
 		System.out.println(" -p : --password    password (\"env:ENV_VAR\" to use password from env)");
-		System.out.println(" -2 : --2fatype     second factor type (one of \"None\", \"TOTP\", \"SMS\")");
 		System.out.println(" -T : --temp        temporary directory");
 	}
 
@@ -397,6 +580,8 @@ public class OraclePatchDownloader {
 		int c;
 		ArrayList<LongOpt> longopts = new ArrayList<>();
 		longopts.add( new LongOpt("help",      LongOpt.NO_ARGUMENT,       null, 'h') );
+		longopts.add( new LongOpt("debug",     LongOpt.NO_ARGUMENT,       null, 'D') );
+		longopts.add( new LongOpt("quiet",     LongOpt.NO_ARGUMENT,       null, 'q') );
 		longopts.add( new LongOpt("directory", LongOpt.REQUIRED_ARGUMENT, null, 'd') );
 		longopts.add( new LongOpt("patches",   LongOpt.REQUIRED_ARGUMENT, null, 'x') );
 		longopts.add( new LongOpt("patchfile", LongOpt.REQUIRED_ARGUMENT, null, 'f') );
@@ -407,7 +592,8 @@ public class OraclePatchDownloader {
 		longopts.add( new LongOpt("2fatype",   LongOpt.REQUIRED_ARGUMENT, null, '2') );
 		longopts.add( new LongOpt("temp",      LongOpt.REQUIRED_ARGUMENT, null, 'T') );
 
-		Getopt g = new Getopt("OraclePatchDownoader", args, "hd:x:f:t:r:u:p:2:T:",
+		Getopt g = new Getopt("OraclePatchDownoader", args,
+													"hDqd:x:f:t:r:u:p:2:T:",
 													longopts.toArray(new LongOpt[longopts.size()]));
 		g.setOpterr(false); // do our own error handling
 		directory = new File(System.getProperty("user.home"));
@@ -421,6 +607,14 @@ public class OraclePatchDownloader {
 			case 'h':
 				help();
 				System.exit(0);
+				break;
+
+			case 'D':
+				debugMode = true;
+				break;
+
+			case 'q':
+				quietMode = true;
 				break;
 
 			case 'd':
@@ -445,9 +639,9 @@ public class OraclePatchDownloader {
 					String line;
 					try (BufferedReader br = new BufferedReader(new FileReader(fp))) {
 						while ((line = br.readLine()) != null) {
-							Matcher matcher = patchPattern.matcher(line.trim());
+							Matcher matcher = PATCH_FILE_LINE_PATTERN.matcher(line.trim());
 							if (matcher.matches()) {
-								String px = matcher.group(2);
+								String px = matcher.group(1);
 								patchList.add(px);
 							}
 						}


### PR DESCRIPTION
build-and-release.yml:

- Add step to upload temporary artifact for non-release builds.

OraclePatchDownloader.java:

- Add debug mode to dump downloaded HTML pages (as XML) and to
  log HTTP requests and responses.

- Rename constants to all-uppercase.  Slightly simplify regexs
  and extend patch number regexs to match 8-10 digit bug numbers.

- Add warn method that also dumps an exception.

- Add some structuring comments.

README.md:

- Sync option description from online help.

- Add section on debug mode.
