### PR TITLE
Use basic authentication, bump HtmlUnit version to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 		<dependency>
 			<groupId>org.htmlunit</groupId>
 			<artifactId>htmlunit</artifactId>
-			<version>3.11.0</version>
+			<version>4.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>gnu.getopt</groupId>


### PR DESCRIPTION
When using a non-browser user agent, MOS accepts basic authentication for patch searches and downloads.  This is much faster since all these JavaScript and CSS files do not need to get downloaded in that case.

This fixes #12.

pom.xml:

- Update HtmlUnit dependency to version 4.1.0.

OraclePatchDownloader.java:

- Set a non-browser user agent.

- Provide MOS credentials through basic authentication.